### PR TITLE
Added bastion public IP output

### DIFF
--- a/hub.tf
+++ b/hub.tf
@@ -85,3 +85,7 @@ resource "oci_core_instance" "bastion_instance" {
   #   create = "60m"
   # }
 }
+
+output "bastion_public_ip" {
+  value = oci_core_instance.bastion_instance.*.public_ip
+}


### PR DESCRIPTION
This PR is to add TF output to display the public IP address of the bastion host created by the stack.